### PR TITLE
Set value of opts.wrtc if specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function HybridSwarm (opts) {
   self.node = null
   self.connections = 0
   self.opts = opts
-  if (opts.wrtc || webRTCSwarm.WEBRTC_SUPPORT) self._browser()
+  opts.wrtc = typeof opts.wrtc !== 'undefined' ? opts.wrtc : webRTCSwarm.WEBRTC_SUPPORT
+  if (opts.wrtc) self._browser()
   if (process.versions.node) self._node()
 }
 


### PR DESCRIPTION
If `opts.wrtc` is specified then it should use that regardless of if `webRTCSwarm.WEBRTC_SUPPORT` is true. 

This allows user to turn off webrtc where it is available but they do not want it by setting `opts.wrtc = false`. 
